### PR TITLE
OkHttp3 3.3.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -188,7 +188,7 @@ var BuildXCode = new Action<FilePath, string, DirectoryPath, TargetOS> ((project
                 Arch = arch,
                 Configuration = "Release",
             });
-            var outputPath = workingDirectory.Combine ("build").Combine (os == TargetOS.Mac ? "Release" : ("Release-" + sdk)).CombineWithFilePath (output);
+            var outputPath = workingDirectory.Combine ("build").Combine (os == TargetOS.Mac ? "Release" : ("Release-" + sdk)).Combine (libraryTitle).CombineWithFilePath (output);
             CopyFile (outputPath, dest);
         }
 	});
@@ -243,11 +243,16 @@ var DownloadPod = new Action<DirectoryPath, string, string, IDictionary<string, 
         var builder = new StringBuilder ();
         builder.AppendFormat ("platform :{0}, '{1}'", platform, platformVersion);
         builder.AppendLine ();
+        if (CocoaPodVersion (new CocoaPodSettings ()) >= new System.Version (1, 0)) {
+            builder.AppendLine ("install! 'cocoapods', :integrate_targets => false");
+        }
+        builder.AppendLine ("target 'Xamarin' do");
         foreach (var pod in pods) {
-            builder.AppendFormat ("pod '{0}', '{1}'", pod.Key, pod.Value);
+            builder.AppendFormat ("  pod '{0}', '{1}'", pod.Key, pod.Value);
             builder.AppendLine ();
         }
-        
+        builder.AppendLine ("end");
+
         if (!DirectoryExists (podfilePath)) {
             CreateDirectory (podfilePath);
         }

--- a/build.cake
+++ b/build.cake
@@ -83,9 +83,9 @@ public enum TargetOS {
 
 const string okio_version                 = "1.6.0"; // OkIO
 const string okhttp_version               = "2.7.5"; // OkHttp
-const string okhttp3_version              = "3.2.0"; // OkHttp3
+const string okhttp3_version              = "3.3.0"; // OkHttp3
 const string okhttpws_version             = "2.7.5"; // OkHttp-WS
-const string okhttp3ws_version            = "3.2.0"; // OkHttp3-WS
+const string okhttp3ws_version            = "3.3.0"; // OkHttp3-WS
 const string okhttpurlconnection_version  = "2.7.5"; // OkHttp-UrlConnection
 const string picasso_version              = "2.5.2"; // Picasso
 const string androidtimessquare_version   = "1.6.5"; // AndroidTimesSquare

--- a/component/square.okhttp3.ws/component.yaml
+++ b/component/square.okhttp3.ws/component.yaml
@@ -5,7 +5,7 @@ id: square.OkHttp3.ws
 publisher: Xamarin Inc
 publisher-url: http://xamarin.com
 summary: A RFC6455-compliant web socket implementation.
-version: 3.2.0.0
+version: 3.3.0.0
 src-url: https://github.com/mattleibow/square-bindings
 
 details: Details.md
@@ -17,8 +17,8 @@ no_build: true
 packages:
   android: 
     - Square.OkIO, Version=1.6.0.0
-    - Square.OkHttp3, Version=3.2.0.0
-    - Square.OkHttp3.WS, Version=3.2.0.0
+    - Square.OkHttp3, Version=3.3.0.0
+    - Square.OkHttp3.WS, Version=3.3.0.0
 libraries: 
   android:
     - ../../output/Square.OkHttp3.WS.dll  

--- a/component/square.okhttp3/component.yaml
+++ b/component/square.okhttp3/component.yaml
@@ -5,7 +5,7 @@ id: square.okhttp3
 publisher: Xamarin Inc
 publisher-url: http://xamarin.com
 summary: An HTTP+HTTP/2 client for Android and Java applications.
-version: 3.2.0.0
+version: 3.3.0.0
 src-url: https://github.com/mattleibow/square-bindings
 
 details: Details.md
@@ -17,7 +17,7 @@ no_build: true
 packages:
   android: 
     - Square.OkIO, Version=1.6.0.0
-    - Square.OkHttp3, Version=3.2.0.0
+    - Square.OkHttp3, Version=3.3.0.0
 libraries: 
   android:
     - ../../output/Square.OkHttp3.dll   

--- a/nuget/Square.OkHttp3.WS.nuspec
+++ b/nuget/Square.OkHttp3.WS.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Square.OkHttp3.WS</id>
-        <version>3.2.0.0</version>
+        <version>3.3.0.0</version>
         <title>OkHttp v3 Web Sockets</title>
         <authors>.NET Development Addict</authors>
         <licenseUrl>https://raw.githubusercontent.com/mattleibow/square-bindings/master/LICENSE</licenseUrl>
@@ -16,7 +16,7 @@
         <tags></tags>
         <dependencies>
             <dependency id="Square.OkIO" version="1.6.0" />
-            <dependency id="Square.OkHttp3" version="3.2.0" />
+            <dependency id="Square.OkHttp3" version="3.3.0" />
         </dependencies>
     </metadata>
     <files>

--- a/nuget/Square.OkHttp3.nuspec
+++ b/nuget/Square.OkHttp3.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>Square.OkHttp3</id>
-        <version>3.2.0.0</version>
+        <version>3.3.0.0</version>
         <title>OkHttp v3</title>
         <authors>.NET Development Addict</authors>
         <licenseUrl>https://raw.githubusercontent.com/mattleibow/square-bindings/master/LICENSE</licenseUrl>


### PR DESCRIPTION
Update to v3.3.0 of OkHttp3

Also fixes CocoaPods to support 1.0+