### PR TITLE
Update to OkHttp version 3.5.

### DIFF
--- a/binding/Square.OkHttp3/Properties/AssemblyInfo.cs
+++ b/binding/Square.OkHttp3/Properties/AssemblyInfo.cs
@@ -26,5 +26,5 @@ using Android.App;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.4.0.0")]
-[assembly: AssemblyFileVersion("3.4.1.0")]
+[assembly: AssemblyVersion("3.5.0.0")]
+[assembly: AssemblyFileVersion("3.5.0.0")]

--- a/binding/Square.OkHttp3/Transforms/Metadata.xml
+++ b/binding/Square.OkHttp3/Transforms/Metadata.xml
@@ -1,5 +1,5 @@
 <metadata>
-  <!--
+    <!--
   This sample removes the class: android.support.v4.content.AsyncTaskLoader.LoadTask:
   <remove-node path="/api/package[@name='android.support.v4.content']/class[@name='AsyncTaskLoader.LoadTask']" />
   
@@ -7,10 +7,11 @@
   <remove-node path="/api/package[@name='android.support.v4.content']/class[@name='CursorLoader']/method[@name='loadInBackground']" />
   -->
 
-  <attr path="/api/package[@name='okhttp3']" name="managedName">Square.OkHttp3</attr>
+    <attr path="/api/package[@name='okhttp3']" name="managedName">Square.OkHttp3</attr>
 
-  <attr path="/api/package[@name='okhttp3']/class[@name='RealCall']" name="visibility">public</attr>
-  <remove-node path="/api/package[starts-with(@name, 'okhttp3.internal')]" />
-  <remove-node path="/api/package/class[@visibility='']" />
+    <attr path="/api/package[@name='okhttp3']/class[@name='RealCall']" name="visibility">public</attr>
+    <attr path="/api/package[@name='okhttp3']/class[@name='RealCall']/method[@name='clone' and count(parameter)=0]" name="managedReturn">Square.OkHttp3.ICall</attr>
+    <remove-node path="/api/package[starts-with(@name, 'okhttp3.internal')]" />
+    <remove-node path="/api/package/class[@visibility='']" />
 
 </metadata>

--- a/build.cake
+++ b/build.cake
@@ -83,7 +83,7 @@ public enum TargetOS {
 
 const string okio_version                 = "1.10.0"; // OkIO
 const string okhttp_version               = "2.7.5"; // OkHttp
-const string okhttp3_version              = "3.4.1"; // OkHttp3
+const string okhttp3_version              = "3.5.0"; // OkHttp3
 const string okhttpws_version             = "2.7.5"; // OkHttp-WS
 const string okhttp3ws_version            = "3.4.1"; // OkHttp3-WS
 const string okhttpurlconnection_version  = "2.7.5"; // OkHttp-UrlConnection

--- a/component/square.okhttp3/component.yaml
+++ b/component/square.okhttp3/component.yaml
@@ -5,7 +5,7 @@ id: square.okhttp3
 publisher: Xamarin Inc
 publisher-url: http://xamarin.com
 summary: An HTTP+HTTP/2 client for Android and Java applications.
-version: 3.4.1.0
+version: 3.5.0.0
 src-url: https://github.com/mattleibow/square-bindings
 
 details: Details.md
@@ -16,8 +16,8 @@ is_shell: true
 no_build: true
 packages:
   android: 
-    - Square.OkIO, Version=1.6.0.0
-    - Square.OkHttp3, Version=3.4.1.0
+    - Square.OkIO, Version=1.10.0.0
+    - Square.OkHttp3, Version=3.5.0.0
 libraries: 
   android:
     - ../../output/Square.OkHttp3.dll   

--- a/sample/OkHttp3Sample/OkHttp3Sample.csproj
+++ b/sample/OkHttp3Sample/OkHttp3Sample.csproj
@@ -14,7 +14,7 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/sample/OkHttp3Sample/OkHttp3Sample.sln
+++ b/sample/OkHttp3Sample/OkHttp3Sample.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.31101.0
+# Visual Studio 14
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Square.OkIO", "..\..\binding\Square.OkIO\Square.OkIO.csproj", "{0ADBD990-1A61-4D2A-B1CD-E46AC63348BE}"
 EndProject
@@ -25,8 +25,10 @@ Global
 		{2DA76115-A022-4275-8119-FB9847254998}.Release|Any CPU.Build.0 = Release|Any CPU
 		{006B4CA9-9FDF-4E1F-81CD-4C7175FCA4F4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{006B4CA9-9FDF-4E1F-81CD-4C7175FCA4F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{006B4CA9-9FDF-4E1F-81CD-4C7175FCA4F4}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
 		{006B4CA9-9FDF-4E1F-81CD-4C7175FCA4F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{006B4CA9-9FDF-4E1F-81CD-4C7175FCA4F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{006B4CA9-9FDF-4E1F-81CD-4C7175FCA4F4}.Release|Any CPU.Deploy.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Requires a minor metadata change to have Clone return iCall instead of RealCall