### PR TITLE
AndroidCodegenTarget added.

### DIFF
--- a/binding/Square.AndroidTimesSquare/Square.AndroidTimesSquare.csproj
+++ b/binding/Square.AndroidTimesSquare/Square.AndroidTimesSquare.csproj
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <AndroidCodegenTarget>XAJavaInterop1</AndroidCodegenTarget>
+  </PropertyGroup>
+  <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{4FE5BA3F-1D95-419E-85D8-8D61ED3C0941}</ProjectGuid>


### PR DESCRIPTION
Newer versions of Xamarin.Android have shipped with a new way of generated android callable wrapper code that's a bit higher performance than the current default.  By setting the AndroidCodegenTarget MSBuild property to `XAJavaInterop1` you can opt into this newer generator.  Please consider merging this and releasing an update to your bindings.  

Thanks!